### PR TITLE
Add NOR flash trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,11 +130,6 @@ pub trait NorFlash {
 	/// erase resolution
 	fn try_erase(&mut self, from: Address, to: Address) -> nb::Result<(), Self::Error>;
 
-	/// The range of possible addresses within the peripheral.
-	///
-	/// (start_addr, end_addr)
-	fn range(&self) -> (Address, Address);
-
 	/// Get all distinct memory reagions. These must not overlap, but can be disjoint.
 	/// Most chips will return a single region, but some chips have regions with
 	/// different erase sizes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,15 @@ pub trait NorFlash {
 	fn regions(&self) -> Vec<Self::Region, U4>;
 }
 
-/// ...
-pub trait UniformNorFlash: NorFlash {
+/// Marker trait for NOR flashes with uniform erase and page sizes across the whole
+/// address range
+pub trait UniformNorFlash {}
+
+/// Automatic implementation of region trait for uniform NOR flashes
+impl<T> NorFlashRegion for T
+where
+	T: NorFlash + UniformNorFlash,
+{
 	/// The range of possible addresses within the peripheral.
 	///
 	/// (start_addr, end_addr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,14 @@ pub trait NorFlashRegion {
 	fn erase_sizes(&self) -> Vec<usize, U5>;
 }
 
+/// Blanket implementation for all types implementing [`NorFlashRegion`]
+impl<T: NorFlashRegion> Region for T {
+	fn contains(&self, address: Address) -> bool {
+		let (start, end) = self.range();
+		address.0 >= start.0 && address.0 < end.0
+	}
+}
+
 /// NOR flash storage trait
 pub trait NorFlash {
 	/// An enumeration of storage errors
@@ -141,11 +149,8 @@ pub trait NorFlash {
 /// address range
 pub trait UniformNorFlash {}
 
-/// Automatic implementation of region trait for uniform NOR flashes
-impl<T> NorFlashRegion for T
-where
-	T: NorFlash + UniformNorFlash,
-{
+/// Blanket implementation for all types implementing [`NorFlash`] and [`UniformNorFlash`]
+impl<T: NorFlash + UniformNorFlash> NorFlashRegion for T {
 	/// The range of possible addresses within the peripheral.
 	///
 	/// (start_addr, end_addr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,3 +136,23 @@ pub trait NorFlash {
 	/// Currently limited to 4 regions, but could be increased if necessary
 	fn regions(&self) -> Vec<Self::Region, U4>;
 }
+
+/// ...
+pub trait UniformNorFlash: NorFlash {
+	/// The range of possible addresses within the peripheral.
+	///
+	/// (start_addr, end_addr)
+	fn range(&self) -> (Address, Address) {
+		self.regions()[0].range()
+	}
+	/// Maximum number of bytes that can be written at once.
+	fn page_size(&self) -> usize {
+		self.regions()[0].page_size()
+	}
+	/// List of avalable erase sizes in this region.
+	/// Should be sorted in ascending order.
+	/// Currently limited to 5 sizes, but could be increased if necessary.
+	fn erase_sizes(&self) -> Vec<usize, U5> {
+		self.regions()[0].erase_sizes()
+	}
+}


### PR DESCRIPTION
This is my first try of a NOR flash trait.

`try_read`, `try_write` and `try_erase` are similar to `ReadWrite`, but with different semantics.

Additionally it can return up to 4 regions with differing erase sizes to account for flashes that support some erase sizes only for specific address ranges.

Ate the moment `regions` and `erase_sizes` return `heapless::Vec`. I don't know if this is the optimal way to go.

This was discussed in #1 and #3.