### PR TITLE
Enhancement: RmwNorFlash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.36.0
+          - rust: 1.50.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ NOR-flash & NAND-flash, both external and internal.
 
 ## [API reference]
 
-[API reference]: https://docs.rs/embedded-storage
-
 ## How-to: add a new trait
 
 This is the suggested approach to adding a new trait to `embedded-storage`
@@ -37,7 +35,7 @@ These issues / PRs will be labeled as `proposal`s in the issue tracker.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.36.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.50.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License
@@ -55,3 +53,5 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+[API reference]: https://docs.rs/embedded-storage

--- a/src/nor_flash.rs
+++ b/src/nor_flash.rs
@@ -225,11 +225,11 @@ where
 			if is_subset {
 				// Use `merge_buffer` as allocation for padding `data` to `WRITE_SIZE`
 				let offset = addr as usize % S::WRITE_SIZE;
-				let alligned_end = data.len() % S::WRITE_SIZE;
-				self.merge_buffer[..S::WRITE_SIZE].fill(0xff);
-				self.merge_buffer[offset..data.len()].copy_from_slice(data);
+				let aligned_end = data.len() % S::WRITE_SIZE + offset + data.len();
+				self.merge_buffer[..aligned_end].fill(0xff);
+				self.merge_buffer[offset..offset + data.len()].copy_from_slice(data);
 				self.storage
-					.try_write(addr - offset as u32, &self.merge_buffer[..S::WRITE_SIZE])?;
+					.try_write(addr - offset as u32, &self.merge_buffer[..aligned_end])?;
 			} else {
 				self.storage.try_erase(page.start, page.end())?;
 				self.merge_buffer[..S::ERASE_SIZE]


### PR DESCRIPTION
This PR implements RMW helpers for Nor flashes. 

It was extracted from the previous PR #12, in order to land the traits and release them faster.