### PR TITLE
Remove try_ prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-* None
+- Removed `try_` prefix from all trait methods.
 
 ## [0.1.0] - 2021-05-18
 
 Initial release to crates.io.
 
-[Unreleased]: https://github.com/rust-embedded-community/embedded-storage/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/rust-embedded-community/embedded-storage/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/rust-embedded-community/embedded-storage/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release to crates.io.
 
-[unreleased]: https://github.com/rust-embedded-community/embedded-storage/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/embedded-storage/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/rust-embedded-community/embedded-storage/releases/tag/v0.1.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub trait ReadStorage {
 	///
 	/// This should throw an error in case `bytes.len()` will be larger than
 	/// `self.capacity() - offset`.
-	fn try_read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error>;
+	fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error>;
 
 	/// The capacity of the storage peripheral in bytes.
 	fn capacity(&self) -> usize;
@@ -43,5 +43,5 @@ pub trait Storage: ReadStorage {
 	/// **NOTE:**
 	/// This function will automatically erase any pages necessary to write the given data,
 	/// and might as such do RMW operations at an undesirable performance impact.
-	fn try_write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error>;
+	fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error>;
 }

--- a/src/nor_flash.rs
+++ b/src/nor_flash.rs
@@ -11,7 +11,7 @@ pub trait ReadNorFlash {
 	///
 	/// This should throw an error in case `bytes.len()` will be larger than
 	/// the peripheral end address.
-	fn try_read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error>;
+	fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error>;
 
 	/// The capacity of the peripheral in bytes.
 	fn capacity(&self) -> usize;
@@ -32,13 +32,13 @@ pub trait NorFlash: ReadNorFlash {
 	/// erase resolution
 	/// If power is lost during erase, contents of the page are undefined.
 	/// `from` and `to` must both be multiples of `ERASE_SIZE` and `from` <= `to`.
-	fn try_erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error>;
+	fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error>;
 
 	/// If power is lost during write, the contents of the written words are undefined,
 	/// but the rest of the page is guaranteed to be unchanged.
 	/// It is not allowed to write to the same word twice.
 	/// `offset` and `bytes.len()` must both be multiples of `WRITE_SIZE`.
-	fn try_write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error>;
+	fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error>;
 }
 
 /// Marker trait for NorFlash relaxing the restrictions on `write`.


### PR DESCRIPTION
In https://github.com/rust-embedded/embedded-hal/pull/268 the `try_` prefix has been removed from all traits.

This PR removes try_ from the embedded-storage traits too, for consistency.