### PR TITLE
Nest ReadNorFlash::Error in a new NorFlashError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Require Nor flashes error types to be convertible to generic errors.
+- Provide helper functions for Nor flashes to check for generic errors.
+
 ## [0.2.0] - 2021-09-15
 
 - Removed `try_` prefix from all trait methods.


### PR DESCRIPTION
This PR tries to address the following question:

It looks like all implementations of the `nor_flash` traits will have to return some `NotAligned` and `OutOfBounds` errors. Why not provide those errors as well as helper functions to check them?

This has the following advantages:
- The `nor_flash` module can provide helper functions since the checks are always the same, reducing the number of errors in implementations.
- The `nor_flash` traits can document which error to return.
- The ecosystem errors are unified, less reinventing of the wheel.

The main disadvantage I see is that it's is a breaking change.

What do you think?