### PR TITLE
Proposal: Add DirectreadNorFlash trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Add `DirectreadNorFlash` trait
+
 ## [0.2.0] - 2021-09-15
 
 - Removed `try_` prefix from all trait methods.

--- a/src/nor_flash.rs
+++ b/src/nor_flash.rs
@@ -19,6 +19,16 @@ pub trait ReadNorFlash {
 	fn capacity(&self) -> usize;
 }
 
+/// Read only NOR flash trait with direct access.
+pub trait DirectreadNorFlash: ReadNorFlash {
+	/// Provides direct access to the storage peripheral, starting at the given address offset
+	/// with the given byte length.
+	///
+	/// This should throw an error if the arguments are out of bounds. Note that there is no
+	/// alignment restriction (i.e. [`ReadNorFlash::READ_SIZE`] should be 1).
+	fn direct_read(&self, offset: u32, length: usize) -> Result<&[u8], Self::Error>;
+}
+
 /// NOR flash trait.
 pub trait NorFlash: ReadNorFlash {
 	/// The minumum number of bytes the storage peripheral can write


### PR DESCRIPTION
Some (most?) flash provide direct read access to the flash, like the nRF52840. This PR adds a trait for them.

Compared to `ReadNorFlash`:
- This enables zero-cost reads (in particular there is no copy of the slice).
- This prevents mutable operations until the slices that have been read are dropped (they could be copied to hold the content longer resulting in the same as using `ReadNorFlash::read` in the first place).