### PR TITLE
Add async version of nor flash

### DIFF
--- a/embedded-storage-async/Cargo.toml
+++ b/embedded-storage-async/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "embedded-storage-async"
+version = "0.2.0"
+authors = [
+    "Mathias Koch <mk@blackbird.online>",
+]
+edition = "2018"
+description = "A Storage Abstraction Layer for Embedded Systems"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-embedded-community/embedded-storage"
+homepage = "https://github.com/rust-embedded-community/embedded-storage"
+documentation = "https://docs.rs/embedded-storage"
+readme = "README.md"
+keywords = ["storage"]
+categories = ["embedded", "hardware-support", "no-std"]
+
+[dependencies]
+embedded-storage = { path = "../" }

--- a/embedded-storage-async/src/lib.rs
+++ b/embedded-storage-async/src/lib.rs
@@ -1,0 +1,9 @@
+//! # embedded-storage-async - An async Storage Abstraction Layer for Embedded Systems
+//!
+//! Storage traits to allow on and off board storage devices to read and write
+//! data asynchronously.
+
+#![no_std]
+#![feature(generic_associated_types)]
+
+pub mod nor_flash;

--- a/embedded-storage-async/src/nor_flash.rs
+++ b/embedded-storage-async/src/nor_flash.rs
@@ -1,0 +1,64 @@
+use core::future::Future;
+use embedded_storage::nor_flash::NorFlashError;
+
+/// Read only NOR flash trait.
+pub trait AsyncReadNorFlash {
+	/// Errors returned by this NOR flash.
+	type Error: NorFlashError;
+
+	/// The minumum number of bytes the storage peripheral can read
+	const READ_SIZE: usize;
+
+	type ReadFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+	where
+		Self: 'a;
+
+	/// Read a slice of data from the storage peripheral, starting the read
+	/// operation at the given address offset, and reading `bytes.len()` bytes.
+	///
+	/// # Errors
+	///
+	/// Returns an error if the arguments are not aligned or out of bounds. The implementation
+	/// can use the [`check_read`] helper function.
+	fn read<'a>(&'a mut self, offset: u32, bytes: &'a mut [u8]) -> Self::ReadFuture<'a>;
+
+	/// The capacity of the peripheral in bytes.
+	fn capacity(&self) -> usize;
+}
+
+/// NOR flash trait.
+pub trait AsyncNorFlash: AsyncReadNorFlash {
+	/// The minumum number of bytes the storage peripheral can write
+	const WRITE_SIZE: usize;
+
+	/// The minumum number of bytes the storage peripheral can erase
+	const ERASE_SIZE: usize;
+
+	/// Erase the given storage range, clearing all data within `[from..to]`.
+	/// The given range will contain all 1s afterwards.
+	///
+	/// If power is lost during erase, contents of the page are undefined.
+	///
+	/// # Errors
+	///
+	/// Returns an error if the arguments are not aligned or out of bounds (the case where `to >
+	/// from` is considered out of bounds). The implementation can use the [`check_erase`]
+	/// helper function.
+	type EraseFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+	where
+		Self: 'a;
+	fn erase<'a>(&'a mut self, from: u32, to: u32) -> Self::EraseFuture<'a>;
+
+	/// If power is lost during write, the contents of the written words are undefined,
+	/// but the rest of the page is guaranteed to be unchanged.
+	/// It is not allowed to write to the same word twice.
+	///
+	/// # Errors
+	///
+	/// Returns an error if the arguments are not aligned or out of bounds. The implementation
+	/// can use the [`check_write`] helper function.
+	type WriteFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+	where
+		Self: 'a;
+	fn write<'a>(&'a mut self, offset: u32, bytes: &'a [u8]) -> Self::WriteFuture<'a>;
+}

--- a/embedded-storage-async/src/nor_flash.rs
+++ b/embedded-storage-async/src/nor_flash.rs
@@ -1,11 +1,8 @@
 use core::future::Future;
-use embedded_storage::nor_flash::NorFlashError;
+use embedded_storage::nor_flash::ErrorType;
 
 /// Read only NOR flash trait.
-pub trait AsyncReadNorFlash {
-	/// Errors returned by this NOR flash.
-	type Error: NorFlashError;
-
+pub trait AsyncReadNorFlash: ErrorType {
 	/// The minumum number of bytes the storage peripheral can read
 	const READ_SIZE: usize;
 

--- a/embedded-storage-async/src/nor_flash.rs
+++ b/embedded-storage-async/src/nor_flash.rs
@@ -31,6 +31,10 @@ pub trait AsyncNorFlash: AsyncReadNorFlash {
 	/// The minumum number of bytes the storage peripheral can erase
 	const ERASE_SIZE: usize;
 
+	type EraseFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+	where
+		Self: 'a;
+
 	/// Erase the given storage range, clearing all data within `[from..to]`.
 	/// The given range will contain all 1s afterwards.
 	///
@@ -41,11 +45,11 @@ pub trait AsyncNorFlash: AsyncReadNorFlash {
 	/// Returns an error if the arguments are not aligned or out of bounds (the case where `to >
 	/// from` is considered out of bounds). The implementation can use the [`check_erase`]
 	/// helper function.
-	type EraseFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
-	where
-		Self: 'a;
 	fn erase<'a>(&'a mut self, from: u32, to: u32) -> Self::EraseFuture<'a>;
 
+	type WriteFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+	where
+		Self: 'a;
 	/// If power is lost during write, the contents of the written words are undefined,
 	/// but the rest of the page is guaranteed to be unchanged.
 	/// It is not allowed to write to the same word twice.
@@ -54,8 +58,5 @@ pub trait AsyncNorFlash: AsyncReadNorFlash {
 	///
 	/// Returns an error if the arguments are not aligned or out of bounds. The implementation
 	/// can use the [`check_write`] helper function.
-	type WriteFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
-	where
-		Self: 'a;
 	fn write<'a>(&'a mut self, offset: u32, bytes: &'a [u8]) -> Self::WriteFuture<'a>;
 }

--- a/src/nor_flash.rs
+++ b/src/nor_flash.rs
@@ -15,6 +15,12 @@ impl NorFlashError for core::convert::Infallible {
 	}
 }
 
+/// A trait that NorFlash implementations can use to share an error type.
+pub trait ErrorType {
+	/// Errors returned by this NOR flash.
+	type Error: NorFlashError;
+}
+
 /// NOR flash error kinds.
 ///
 /// NOR flash implementations must map their error to those generic error kinds through the
@@ -49,10 +55,7 @@ impl core::fmt::Display for NorFlashErrorKind {
 }
 
 /// Read only NOR flash trait.
-pub trait ReadNorFlash {
-	/// Errors returned by this NOR flash.
-	type Error: NorFlashError;
-
+pub trait ReadNorFlash: ErrorType {
 	/// The minumum number of bytes the storage peripheral can read
 	const READ_SIZE: usize;
 


### PR DESCRIPTION
Add async version of the nor_flash traits, that can be used in an
async context. In the same way as embedded_hal_async in relation to
embedded_hal, the traits are stored in a separate crate, with the
intention of moving to the main crate once the async GAT feature is part
of Rust stable.