### PR TITLE
async: remove "Async" prefix in trait names.

### DIFF
--- a/embedded-storage-async/Cargo.toml
+++ b/embedded-storage-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-storage-async"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Mathias Koch <mk@blackbird.online>",
 ]

--- a/embedded-storage-async/rust-toolchain.toml
+++ b/embedded-storage-async/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Before upgrading check that everything is available on all tier1 targets here:
+# https://rust-lang.github.io/rustup-components-history
+[toolchain]
+channel = "nightly-2022-11-22"
+components = ["clippy"]

--- a/embedded-storage-async/src/lib.rs
+++ b/embedded-storage-async/src/lib.rs
@@ -4,6 +4,7 @@
 //! data asynchronously.
 
 #![no_std]
-#![feature(generic_associated_types)]
+#![feature(async_fn_in_trait)]
+#![allow(incomplete_features)]
 
 pub mod nor_flash;

--- a/embedded-storage-async/src/nor_flash.rs
+++ b/embedded-storage-async/src/nor_flash.rs
@@ -1,14 +1,9 @@
-use core::future::Future;
 use embedded_storage::nor_flash::ErrorType;
 
 /// Read only NOR flash trait.
 pub trait AsyncReadNorFlash: ErrorType {
 	/// The minumum number of bytes the storage peripheral can read
 	const READ_SIZE: usize;
-
-	type ReadFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
-	where
-		Self: 'a;
 
 	/// Read a slice of data from the storage peripheral, starting the read
 	/// operation at the given address offset, and reading `bytes.len()` bytes.
@@ -17,7 +12,7 @@ pub trait AsyncReadNorFlash: ErrorType {
 	///
 	/// Returns an error if the arguments are not aligned or out of bounds. The implementation
 	/// can use the [`check_read`] helper function.
-	fn read<'a>(&'a mut self, offset: u32, bytes: &'a mut [u8]) -> Self::ReadFuture<'a>;
+	async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error>;
 
 	/// The capacity of the peripheral in bytes.
 	fn capacity(&self) -> usize;
@@ -31,10 +26,6 @@ pub trait AsyncNorFlash: AsyncReadNorFlash {
 	/// The minumum number of bytes the storage peripheral can erase
 	const ERASE_SIZE: usize;
 
-	type EraseFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
-	where
-		Self: 'a;
-
 	/// Erase the given storage range, clearing all data within `[from..to]`.
 	/// The given range will contain all 1s afterwards.
 	///
@@ -45,11 +36,8 @@ pub trait AsyncNorFlash: AsyncReadNorFlash {
 	/// Returns an error if the arguments are not aligned or out of bounds (the case where `to >
 	/// from` is considered out of bounds). The implementation can use the [`check_erase`]
 	/// helper function.
-	fn erase<'a>(&'a mut self, from: u32, to: u32) -> Self::EraseFuture<'a>;
+	async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error>;
 
-	type WriteFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
-	where
-		Self: 'a;
 	/// If power is lost during write, the contents of the written words are undefined,
 	/// but the rest of the page is guaranteed to be unchanged.
 	/// It is not allowed to write to the same word twice.
@@ -58,5 +46,5 @@ pub trait AsyncNorFlash: AsyncReadNorFlash {
 	///
 	/// Returns an error if the arguments are not aligned or out of bounds. The implementation
 	/// can use the [`check_write`] helper function.
-	fn write<'a>(&'a mut self, offset: u32, bytes: &'a [u8]) -> Self::WriteFuture<'a>;
+	async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error>;
 }

--- a/embedded-storage-async/src/nor_flash.rs
+++ b/embedded-storage-async/src/nor_flash.rs
@@ -1,7 +1,7 @@
 use embedded_storage::nor_flash::ErrorType;
 
 /// Read only NOR flash trait.
-pub trait AsyncReadNorFlash: ErrorType {
+pub trait ReadNorFlash: ErrorType {
 	/// The minumum number of bytes the storage peripheral can read
 	const READ_SIZE: usize;
 
@@ -19,7 +19,7 @@ pub trait AsyncReadNorFlash: ErrorType {
 }
 
 /// NOR flash trait.
-pub trait AsyncNorFlash: AsyncReadNorFlash {
+pub trait NorFlash: ReadNorFlash {
 	/// The minumum number of bytes the storage peripheral can write
 	const WRITE_SIZE: usize;
 


### PR DESCRIPTION
If we're going to do an `embedded-storage-async` major bump we should sneak this in I think.

Prefixing with `async` is not needed if the traits are in a separate crate, and this way
makes naming consistent with what `embedded-hal(-async)` does.

Depends on #29 