### PR TITLE
Remove sync ErrorType implementation for &mut

### DIFF
--- a/embedded-storage-async/src/nor_flash.rs
+++ b/embedded-storage-async/src/nor_flash.rs
@@ -49,10 +49,6 @@ pub trait NorFlash: ReadNorFlash {
 	async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error>;
 }
 
-impl<T: ErrorType> ErrorType for &mut T {
-	type Error = T::Error;
-}
-
 impl<T: ReadNorFlash> ReadNorFlash for &mut T {
 	const READ_SIZE: usize = T::READ_SIZE;
 


### PR DESCRIPTION
This fixes the regression introduced in #33. The ErrorType is shared for both the sync and async variant, so there should only be one implemenetation