### PR TITLE
Upgrade toolchain

### DIFF
--- a/embedded-storage-async/CHANGELOG.md
+++ b/embedded-storage-async/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 - Let `&mut` `NorFlash` implement `NorFlash`.
+- Use now stabilized `async_fn_in_trait` and `impl_trait_projections`.
 
 ## [0.4.0] - 2022-12-01
 

--- a/embedded-storage-async/rust-toolchain.toml
+++ b/embedded-storage-async/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2022-11-22"
+channel = "nightly-2023-10-21"
 components = ["clippy"]

--- a/embedded-storage-async/src/lib.rs
+++ b/embedded-storage-async/src/lib.rs
@@ -4,8 +4,6 @@
 //! data asynchronously.
 
 #![no_std]
-#![feature(async_fn_in_trait)]
-#![feature(impl_trait_projections)]
-#![allow(incomplete_features)]
+#![allow(async_fn_in_trait)]
 
 pub mod nor_flash;


### PR DESCRIPTION
The 2023-10-21 toolchain seems to have all components according to https://rust-lang.github.io/rustup-components-history/