### PR TITLE
async: reexport nor flash errors.

### DIFF
--- a/embedded-storage-async/src/nor_flash.rs
+++ b/embedded-storage-async/src/nor_flash.rs
@@ -1,4 +1,4 @@
-use embedded_storage::nor_flash::ErrorType;
+pub use embedded_storage::nor_flash::{ErrorType, NorFlashError, NorFlashErrorKind};
 
 /// Read only NOR flash trait.
 pub trait ReadNorFlash: ErrorType {


### PR DESCRIPTION
This is necessary to allow using the -async crate *only*.
