### PR TITLE
Switch to stable toolchain

### DIFF
--- a/embedded-storage-async/Cargo.toml
+++ b/embedded-storage-async/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
     "Diego Barrios Romero <eldruin@gmail.com>",
 ]
 edition = "2018"
+rust-version = "1.75"
 description = "A Storage Abstraction Layer for Embedded Systems"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-embedded-community/embedded-storage"

--- a/embedded-storage-async/README.md
+++ b/embedded-storage-async/README.md
@@ -4,6 +4,10 @@
 
 This create defines a set of async traits variants of embedded-storage.
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.75.0 and up.
+
 ## License
 
 Licensed under either of

--- a/embedded-storage-async/rust-toolchain.toml
+++ b/embedded-storage-async/rust-toolchain.toml
@@ -1,5 +1,0 @@
-# Before upgrading check that everything is available on all tier1 targets here:
-# https://rust-lang.github.io/rustup-components-history
-[toolchain]
-channel = "nightly-2023-10-21"
-components = ["clippy"]


### PR DESCRIPTION
With async fn in traits stabilized in rust 1.75, there is no need to depends on nightly.