### PR TITLE
Optimize OverlapIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-No unreleased changes yet
+- Add `start()` and `end()` method to the `Region` trait.
 
 ## [0.3.1] - 2023-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 - Add `start()` and `end()` method to the `Region` trait.
+- Much faster `OverlapIterator`.
 
 ## [0.3.1] - 2023-12-04
 

--- a/embedded-storage-async/src/nor_flash.rs
+++ b/embedded-storage-async/src/nor_flash.rs
@@ -102,17 +102,15 @@ impl Page {
 			size,
 		}
 	}
-
-	/// The end address of the page
-	const fn end(&self) -> u32 {
-		self.start + self.size as u32
-	}
 }
 
 impl Region for Page {
-	/// Checks if an address offset is contained within the page
-	fn contains(&self, address: u32) -> bool {
-		(self.start <= address) && (self.end() > address)
+	fn start(&self) -> u32 {
+		self.start
+	}
+
+	fn end(&self) -> u32 {
+		self.start + self.size as u32
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,16 @@ pub mod nor_flash;
 
 /// A region denotes a contiguous piece of memory between two addresses.
 pub trait Region {
+	/// Start address of the region of `Self`
+	fn start(&self) -> u32;
+
+	/// End address of the region of `Self`
+	fn end(&self) -> u32;
+
 	/// Check if `address` is contained in the region of `Self`
-	fn contains(&self, address: u32) -> bool;
+	fn contains(&self, address: u32) -> bool {
+		(address >= self.start()) && (address < self.end())
+	}
 }
 
 /// Transparent read only storage trait

--- a/src/nor_flash.rs
+++ b/src/nor_flash.rs
@@ -202,17 +202,15 @@ impl Page {
 			size,
 		}
 	}
-
-	/// The end address of the page
-	const fn end(&self) -> u32 {
-		self.start + self.size as u32
-	}
 }
 
 impl Region for Page {
-	/// Checks if an address offset is contained within the page
-	fn contains(&self, address: u32) -> bool {
-		(self.start <= address) && (self.end() > address)
+	fn start(&self) -> u32 {
+		self.start
+	}
+
+	fn end(&self) -> u32 {
+		self.start + self.size as u32
 	}
 }
 


### PR DESCRIPTION
In my project, I noticed that writing to flash was pretty slow, so I tried to trace it out, and I pin-pointed the culprit to the `OverlapIterator`.

This PR optimizes the `OverlapIterator` so that in my test case, writing a 400 kB file to flash went down from 204 s to 14 s !
So basically, I went from unusable to good enough with just this change.

Note that to optimize the `OverlapIterator`, it needs to know the start and end of the `Region`, so I needed to add those the the `Region` trait. So this is a breaking change and will require a version bump.

I'm not sure how do you prefer to handle this version bump ? Would you like me to include it in this PR ? (I propose to bump embedded-storage to 0.4.0)

For the record, my test case is running on a STM32F407 with an external SPI flash (W25Q32) handled by the `w25q32jv` crate (implementing `embedded-storage`) and formatted as FAT32 using `embedded-fatfs`. The whole thing is running with `embassy` and I'm downloading the file thru HTTP on the ethernet port using `reqwless`.
