### PR TITLE
Add a NOR trait to encode that word clearing is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Add `WordclearNorFlash` to encode relaxed `write` requirements similar to `MultiwriteNorFlash` but that allows for flashes with ECC.
 - Add `start()` and `end()` method to the `Region` trait.
 - Much faster `OverlapIterator`.
 

--- a/src/nor_flash.rs
+++ b/src/nor_flash.rs
@@ -180,6 +180,15 @@ impl<T: NorFlash> NorFlash for &mut T {
 
 /// Marker trait for NorFlash relaxing the restrictions on `write`.
 ///
+/// Writes to the same word twice are now allowed as long as the second write is all 0s.
+/// This is common for flashes that have ECC, where after the first write only a complete clear of
+/// the word is allowed after initial write.
+pub trait WordclearNorFlash: NorFlash {}
+
+impl<T> WordclearNorFlash for T where T: MultiwriteNorFlash {}
+
+/// Marker trait for NorFlash relaxing the restrictions on `write`.
+///
 /// Writes to the same word twice are now allowed. The result is the logical AND of the
 /// previous data and the written data. That is, it is only possible to change 1 bits to 0 bits.
 ///


### PR DESCRIPTION
This is to encode MCU flashes that have ECC, where it is common that only a complete clear of the word is allowed. This is a more restrictive version of `MultiwriteNorFlash` as it cannot encode flashes with ECC support.

Example use-case of this trait: https://github.com/tweedegolf/sequential-storage/pull/63