### PR TITLE
Added usize to read, elided lifetimes, and docs

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,13 +13,13 @@ where
 }
 
 /// Trait allowing us to automatically add an `overlaps` function to all iterators over [`Region`]
-pub trait IterableByOverlaps<'a, R, I>
+pub trait IterableByOverlaps<R, I>
 where
 	R: Region,
 	I: Iterator<Item = R>,
 {
 	/// Obtain an [`OverlapIterator`] over a subslice of `memory` that overlaps with the region in `self`
-	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<R, I>;
+	fn overlaps(self, memory: &[u8], base_address: u32) -> OverlapIterator<R, I>;
 }
 
 impl<'a, R, I> Iterator for OverlapIterator<'a, R, I>
@@ -32,7 +32,7 @@ where
 	fn next(&mut self) -> Option<Self::Item> {
 		let mem_start = self.base_address;
 		let mem_end = self.base_address + self.memory.len() as u32;
-		while let Some(region) = self.regions.next() {
+		for region in self.regions.by_ref() {
 			if mem_start < region.end() && mem_end >= region.start() {
 				let addr_start = core::cmp::max(mem_start, region.start());
 				let addr_end = core::cmp::min(mem_end, region.end());
@@ -46,12 +46,12 @@ where
 }
 
 /// Blanket implementation for all types implementing [`Iterator`] over [`Regions`]
-impl<'a, R, I> IterableByOverlaps<'a, R, I> for I
+impl<R, I> IterableByOverlaps<R, I> for I
 where
 	R: Region,
 	I: Iterator<Item = R>,
 {
-	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<R, I> {
+	fn overlaps(self, memory: &[u8], base_address: u32) -> OverlapIterator<R, I> {
 		OverlapIterator {
 			memory,
 			regions: self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,8 @@ pub trait ReadStorage {
 
 	/// Read a slice of data from the storage peripheral, starting the read
 	/// operation at the given address offset, and reading `bytes.len()` bytes.
-	///
-	/// This should throw an error in case `bytes.len()` will be larger than
-	/// `self.capacity() - offset`.
-	fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error>;
+	/// This should return how many bytes were read into the `bytes` slice allowing for sub-slices that are exclusively read information, or an error
+	fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<usize, Self::Error>;
 
 	/// The capacity of the storage peripheral in bytes.
 	fn capacity(&self) -> usize;


### PR DESCRIPTION
Added support for uzise values returning from `ReadStorage.read` to enable the use of fixed sized buffers, removed unnecessary lifetimes specifiers that could be elided, and filled out some of the empty docs. This can resolve #63