### PR TITLE
Add `ReadNorFlash::read_if_not_empty`

### DIFF
--- a/src/nor_flash.rs
+++ b/src/nor_flash.rs
@@ -68,6 +68,24 @@ pub trait ReadNorFlash: ErrorType {
 	/// can use the [`check_read`] helper function.
 	fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error>;
 
+	/// Read a slice of data from the storage peripheral, starting the read
+	/// operation at the given address offset, and reading `bytes.len()` bytes.
+	///
+	/// The function returns `Ok(true)` if the data is considered to be non-empty.
+	/// The value of `bytes` should not be considered reliable if the function returns `Ok(false)`.
+	///
+	/// This function is useful for devices that offer transparent flash encryption,
+	/// and for devices where the erased byte value is not `0xFF`.
+	///
+	/// # Errors
+	///
+	/// Returns an error if the arguments are not aligned or out of bounds. The implementation
+	/// can use the [`check_read`] helper function.
+	fn read_if_not_empty(&mut self, offset: u32, bytes: &mut [u8]) -> Result<bool, Self::Error> {
+		self.read(offset, bytes)?;
+		Ok(!bytes.iter().all(|&b| b == 0xFF))
+	}
+
 	/// The capacity of the peripheral in bytes.
 	fn capacity(&self) -> usize;
 }


### PR DESCRIPTION
This is a somewhat experimental change, where I'm mainly looking for feedback at first. There are two cases I can imagine, where erased flash may not read back as `0xFF`:

- Devices with transparent flash encryption, like the ESP32
- Certain CMSIS-Packs ([example](https://github.com/probe-rs/probe-rs/blob/21739db0b6881f930e1a18ef84a6e56360f0951f/probe-rs/targets/HK32F030xMxx_Series.yaml#L1391)) indicate this, although I'm not sure whether this is an error in the pack.

In "normal" cases, `read_if_not_empty` just issues a single read and checks the bytes, like in the default implementation. In the case of ESP32, the implementation would issue a decryption-bypassing read first to check for the empty value, then read the decrypted bytes again if not empty.

The goal of this addition is to enable storage solutions to work with flash encryption without any additional marker traits or similar complications.