### PR TITLE
Fixes errors when building docs.

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -45,7 +45,7 @@ where
 	}
 }
 
-/// Blanket implementation for all types implementing [`Iterator`] over [`Regions`]
+/// Blanket implementation for all types implementing [`Iterator`] over [`Region`]
 impl<'a, R, I> IterableByOverlaps<'a, R, I> for I
 where
 	R: Region,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
-/// Currently contains [`OverlapIterator`]
+/// Currently contains [`OverlapIterator`](iter::OverlapIterator)
 pub mod iter;
 /// Technology specific traits for NOR Flashes
 pub mod nor_flash;


### PR DESCRIPTION
Fixes:

```text
warning: unresolved link to `OverlapIterator`
  --> src\lib.rs:13:26
   |
13 | /// Currently contains [`OverlapIterator`]
   |                          ^^^^^^^^^^^^^^^ no item named `OverlapIterator` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: unresolved link to `Regions`
  --> src\iter.rs:48:75
   |
48 | /// Blanket implementation for all types implementing [`Iterator`] over [`Regions`]
   |                                                                           ^^^^^^^ no item named `Regions` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: `embedded-storage` (lib doc) generated 2 warnings
```