### PR TITLE
Add defmt support gated behind a feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ documentation = "https://docs.rs/embedded-storage"
 readme = "README.md"
 keywords = ["storage"]
 categories = ["embedded", "hardware-support", "no-std"]
+
+[features]
+defmt = ["dep:defmt"]
+
+[dependencies]
+defmt = { version = "1.0.1", optional = true }

--- a/embedded-storage-async/Cargo.toml
+++ b/embedded-storage-async/Cargo.toml
@@ -17,5 +17,9 @@ readme = "README.md"
 keywords = ["storage"]
 categories = ["embedded", "hardware-support", "no-std"]
 
+[features]
+defmt = ["dep:defmt", "embedded-storage/defmt"]
+
 [dependencies]
 embedded-storage = { version = "0.3.1", path = "../" }
+defmt = { version = "1.0.1", optional = true }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -19,7 +19,7 @@ where
 	I: Iterator<Item = R>,
 {
 	/// Obtain an [`OverlapIterator`] over a subslice of `memory` that overlaps with the region in `self`
-	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<R, I>;
+	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<'a, R, I>;
 }
 
 impl<'a, R, I> Iterator for OverlapIterator<'a, R, I>
@@ -54,7 +54,7 @@ where
 	R: Region,
 	I: Iterator<Item = R>,
 {
-	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<R, I> {
+	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<'a, R, I> {
 		OverlapIterator {
 			memory,
 			regions: self,

--- a/src/nor_flash.rs
+++ b/src/nor_flash.rs
@@ -4,7 +4,18 @@ use crate::{iter::IterableByOverlaps, ReadStorage, Region, Storage};
 ///
 /// NOR flash implementations must use an error type implementing this trait. This permits generic
 /// code to extract a generic error kind.
+#[cfg(not(feature = "defmt"))]
 pub trait NorFlashError: core::fmt::Debug {
+	/// Convert a specific NOR flash error into a generic error kind.
+	fn kind(&self) -> NorFlashErrorKind;
+}
+
+/// NOR flash errors.
+///
+/// NOR flash implementations must use an error type implementing this trait. This permits generic
+/// code to extract a generic error kind.
+#[cfg(feature = "defmt")]
+pub trait NorFlashError: core::fmt::Debug + defmt::Format {
 	/// Convert a specific NOR flash error into a generic error kind.
 	fn kind(&self) -> NorFlashErrorKind;
 }
@@ -26,6 +37,7 @@ pub trait ErrorType {
 /// NOR flash implementations must map their error to those generic error kinds through the
 /// [`NorFlashError`] trait.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum NorFlashErrorKind {
 	/// The arguments are not properly aligned.


### PR DESCRIPTION
This adds defmt support gated behind a feature flag. It adds it to the release/0.3.1 branch because (1) there are changes to the main branch that are not backward compatible, and (2) there appears to be very little work on the main range. So in order to make the defmt support most available to me and to packages that depend on 3.x (and async 0.4.x), I felt it was best made on the release/0.3.1 branch.