### PR TITLE
Release async v0.4.2

### DIFF
--- a/embedded-storage-async/CHANGELOG.md
+++ b/embedded-storage-async/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [0.4.2] - 2025-12-15
+
 - Add RMW helpers for Nor flashes, implementing `Storage` trait.
 - Let `&mut` `MultiwriteNorFlash` implement `MultiwriteNorFlash`.
 
@@ -26,7 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release to crates.io.
 
-[Unreleased]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.4.1...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.4.2...HEAD
+[0.4.2]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.4.1...embedded-storage-async-v0.4.2
 [0.4.1]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.4.0...embedded-storage-async-v0.4.1
 [0.4.0]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.3.0...embedded-storage-async-v0.4.0
 [0.3.0]: https://github.com/rust-embedded-community/embedded-storage/releases/tag/embedded-storage-async-v0.3.0

--- a/embedded-storage-async/Cargo.toml
+++ b/embedded-storage-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-storage-async"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     "Mathias Koch <mk@blackbird.online>",
     "Ulf Lilleengen <lulf@redhat.com>",


### PR DESCRIPTION
After this is merged, someone needs to publish it and add the v0.4.2 tag