### PR TITLE
Revert "Release async v0.4.2"

### DIFF
--- a/embedded-storage-async/CHANGELOG.md
+++ b/embedded-storage-async/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## [0.4.2] - 2025-12-15
-
 - Add RMW helpers for Nor flashes, implementing `Storage` trait.
 - Let `&mut` `MultiwriteNorFlash` implement `MultiwriteNorFlash`.
 
@@ -28,8 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release to crates.io.
 
-[Unreleased]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.4.2...HEAD
-[0.4.2]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.4.1...embedded-storage-async-v0.4.2
+[Unreleased]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.4.1...HEAD
 [0.4.1]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.4.0...embedded-storage-async-v0.4.1
 [0.4.0]: https://github.com/rust-embedded-community/embedded-storage/compare/embedded-storage-async-v0.3.0...embedded-storage-async-v0.4.0
 [0.3.0]: https://github.com/rust-embedded-community/embedded-storage/releases/tag/embedded-storage-async-v0.3.0

--- a/embedded-storage-async/Cargo.toml
+++ b/embedded-storage-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-storage-async"
-version = "0.4.2"
+version = "0.4.1"
 authors = [
     "Mathias Koch <mk@blackbird.online>",
     "Ulf Lilleengen <lulf@redhat.com>",


### PR DESCRIPTION
Reverts rust-embedded-community/embedded-storage#74

Can't be released as expected. Must be a breaking change. So let's undo the PR