### PR TITLE
Adds html_root_url for embedded-storage-async

### DIFF
--- a/embedded-storage-async/src/lib.rs
+++ b/embedded-storage-async/src/lib.rs
@@ -3,6 +3,7 @@
 //! Storage traits to allow on and off board storage devices to read and write
 //! data asynchronously.
 
+#![doc(html_root_url = "https://docs.rs/embedded-storage-async/0.4.1")]
 #![no_std]
 #![allow(async_fn_in_trait)]
 


### PR DESCRIPTION
Adds `#![doc(html_root_url = "...")]` to embedded-storage-async similarly to embedded-storage. This allows consumer crates to link to the docs on docs.rs.