### PR TITLE
fix hiding a lifetime warning

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -19,7 +19,7 @@ where
 	I: Iterator<Item = R>,
 {
 	/// Obtain an [`OverlapIterator`] over a subslice of `memory` that overlaps with the region in `self`
-	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<R, I>;
+	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<'a, R, I>;
 }
 
 impl<'a, R, I> Iterator for OverlapIterator<'a, R, I>
@@ -51,7 +51,7 @@ where
 	R: Region,
 	I: Iterator<Item = R>,
 {
-	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<R, I> {
+	fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<'a, R, I> {
 		OverlapIterator {
 			memory,
 			regions: self,


### PR DESCRIPTION
warning: hiding a lifetime that's named elsewhere is confusing
   ╭▸ .../embedded-storage/src/iter.rs:22:60
   │
22 │ …memory: &'a [u8], base_address: u32) -> OverlapIterator<R, I>;
   │           ── the lifetime is named here  ━━━━━━━━━━━━━━━━━━━━━ the same lifetime is hidden here
   │
   ├ help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   ╰ note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: consistently use `'a`
   ╭╴
22 │     fn overlaps(self, memory: &'a [u8], base_address: u32) -> OverlapIterator<'a, R, I>;
   ╰╴                                                                              +++